### PR TITLE
fix AxisPairTrigger rotation checks & make PressedTrigger work as advertised

### DIFF
--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -177,7 +177,7 @@ impl<A: Actionlike> Trigger for AxisPairTrigger<A> {
                 (length >= self.min_length
                     && length <= self.max_length
                     && rotation
-                        .map(|rotation| match self.min_rotation <= self.max_rotation {
+                        .map(|rotation| match self.min_rotation < self.max_rotation {
                             true => rotation >= self.min_rotation && rotation <= self.max_rotation,
                             false => rotation >= self.min_rotation || rotation <= self.max_rotation,
                         })
@@ -398,7 +398,7 @@ impl<A: Actionlike> BoolTrigger for PressedTrigger<A> {
                     type_name::<A>()
                 )
             })
-            .just_pressed(action.clone())
+            .pressed(action.clone())
     }
 }
 


### PR DESCRIPTION
the changes should be fairly self-explanatory, but for reference:
* the AxisPairTrigger's rotation checks were working incorrectly for non rotation-constrained instances (i.e. `min_rotation == max_rotation`)
* PressedTrigger was using the wrong method for performing its check