### PR TITLE
Using System for Trigger

### DIFF
--- a/examples/chase.rs
+++ b/examples/chase.rs
@@ -89,7 +89,7 @@ impl Trigger for Near {
     // transition for each entity that is in a state that can transition on this trigger. return
     // `Ok` to trigger or `Err` to not trigger.
     fn trigger(
-        &self,
+        &mut self,
         entity: Entity,
         (transforms, _time): Self::Param<'_, '_>,
     ) -> Result<f32, f32> {


### PR DESCRIPTION
Hello.
Bevy has its own mechanics to handle functions with `SystemParam` and corresponding `SystemState`.
This PR aim to
  * use it in `TransitionImpl` rather than implement
  * add interoperability for `System` and `Trigger`

The interoperability implemented as wrappers: `TriggerSystemFunction` and `SystemFunctionTrigger`.
I'm not so sure this is good implement.
I couldn't
  * implement `IntoSystem` on `T: Trigger` directly
  * implement without breaking change

## Breaking Change
`Trigger::trigger(&self, ...)` -> `Trigger::trigger(&mut self, ...)`