### PR TITLE
add Clone on triggers if available

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -79,7 +79,9 @@ where
 
     fn run(&mut self, world: &World, entity: Entity) -> Option<(Box<dyn Insert>, TypeId)> {
         let state = self.system_state.as_mut().unwrap();
-        let Ok(res) = self.trigger.trigger(entity, state.get(world)) else { return None };
+        let Ok(res) = self.trigger.trigger(entity, state.get(world)) else {
+            return None;
+        };
         (self.builder)(Prev::from_entity(entity, world), res)
             .map(|state| (Box::new(state) as Box<dyn Insert>, TypeId::of::<Next>()))
     }
@@ -286,7 +288,9 @@ impl StateMachine {
             .iter_mut()
             .filter(|(type_id, _)| *type_id == current || *type_id == TypeId::of::<AnyState>())
             .find_map(|(_, transition)| transition.run(world, entity))
-            else { return };
+        else {
+            return;
+        };
         let to = &self.states[&next_state];
 
         for event in from.on_exit.iter() {

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -185,6 +185,7 @@ impl<T: Trigger + Clone> Clone for NotTrigger<T> {
         Self(self.0.clone())
     }
 }
+
 impl<T: Trigger + Copy> Copy for NotTrigger<T> {}
 
 /// Trigger that combines two triggers by logical AND
@@ -214,6 +215,7 @@ impl<T: Trigger + Clone, U: Trigger + Clone> Clone for AndTrigger<T, U> {
         Self(self.0.clone(), self.1.clone())
     }
 }
+
 impl<T: Trigger + Copy, U: Trigger + Copy> Copy for AndTrigger<T, U> {}
 
 /// Trigger that combines two triggers by logical OR
@@ -246,6 +248,7 @@ impl<T: Trigger + Clone, U: Trigger + Clone> Clone for OrTrigger<T, U> {
         Self(self.0.clone(), self.1.clone())
     }
 }
+
 impl<T: Trigger + Copy, U: Trigger + Copy> Copy for OrTrigger<T, U> {}
 
 /// Marker component that represents that the current state has completed. Removed from every entity

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -30,7 +30,7 @@ pub(crate) fn trigger_plugin(app: &mut App) {
 
 /// Wrapper for [`core::convert::Infallible`]. Use for [`Trigger::Err`] if the trigger is
 /// infallible.
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Debug, Deref, DerefMut, Clone, Copy, PartialEq, Eq)]
 pub struct Never {
     never: Infallible,
 }
@@ -145,7 +145,7 @@ impl<T: BoolTrigger> OptionTrigger for T {
 }
 
 /// Trigger that always transitions
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct AlwaysTrigger;
 
 impl Trigger for AlwaysTrigger {
@@ -180,6 +180,13 @@ impl<T: Trigger> Trigger for NotTrigger<T> {
     }
 }
 
+impl<T: Trigger + Clone> Clone for NotTrigger<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+impl<T: Trigger + Copy> Copy for NotTrigger<T> {}
+
 /// Trigger that combines two triggers by logical AND
 #[derive(Debug)]
 pub struct AndTrigger<T: Trigger, U: Trigger>(pub T, pub U);
@@ -201,6 +208,13 @@ impl<T: Trigger, U: Trigger> Trigger for AndTrigger<T, U> {
         ))
     }
 }
+
+impl<T: Trigger + Clone, U: Trigger + Clone> Clone for AndTrigger<T, U> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
+}
+impl<T: Trigger + Copy, U: Trigger + Copy> Copy for AndTrigger<T, U> {}
 
 /// Trigger that combines two triggers by logical OR
 #[derive(Debug)]
@@ -227,9 +241,16 @@ impl<T: Trigger, U: Trigger> Trigger for OrTrigger<T, U> {
     }
 }
 
+impl<T: Trigger + Clone, U: Trigger + Clone> Clone for OrTrigger<T, U> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
+}
+impl<T: Trigger + Copy, U: Trigger + Copy> Copy for OrTrigger<T, U> {}
+
 /// Marker component that represents that the current state has completed. Removed from every entity
 /// each frame after checking triggers. To be used with [`DoneTrigger`].
-#[derive(Component, Debug, Eq, PartialEq)]
+#[derive(Component, Debug, Eq, PartialEq, Clone, Copy)]
 #[component(storage = "SparseSet")]
 pub enum Done {
     /// Success variant
@@ -239,7 +260,7 @@ pub enum Done {
 }
 
 /// Trigger that transitions if the entity has the [`Done`] component with the associated variant
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum DoneTrigger {
     /// Success variant
     Success,
@@ -268,7 +289,7 @@ impl DoneTrigger {
 }
 
 /// Trigger that transitions when it receives the associated event
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct EventTrigger<T: Clone + Event>(PhantomData<T>);
 
 impl<T: Clone + Event> OptionTrigger for EventTrigger<T> {

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -7,7 +7,7 @@ use leafwing_input_manager::{
 use crate::prelude::*;
 
 /// Trigger that transitions if the given [`Actionlike`]'s value is within the given bounds
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValueTrigger<A: Actionlike> {
     /// The action
     pub action: A,
@@ -69,7 +69,7 @@ impl<A: Actionlike> ValueTrigger<A> {
 }
 
 /// Trigger that transitions if the given [`Actionlike`]'s value is within the given bounds
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ClampedValueTrigger<A: Actionlike> {
     /// The action
     pub action: A,
@@ -132,7 +132,7 @@ impl<A: Actionlike> ClampedValueTrigger<A> {
 
 /// Trigger that transitions if the given [`Actionlike`]'s [`DualAxisData`] is within the given
 /// bounds
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AxisPairTrigger<A: Actionlike> {
     /// The action
     pub action: A,
@@ -247,7 +247,7 @@ impl<A: Actionlike> AxisPairTrigger<A> {
 
 /// Trigger that transitions if the given [`Actionlike`]'s [`DualAxisData`] is within the given
 /// bounds
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ClampedAxisPairTrigger<A: Actionlike> {
     /// The action
     pub action: A,
@@ -361,7 +361,7 @@ impl<A: Actionlike> ClampedAxisPairTrigger<A> {
 }
 
 /// Trigger that transitions upon pressing the given [`Actionlike`]
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Debug, Deref, DerefMut, Clone)]
 pub struct JustPressedTrigger<A: Actionlike>(pub A);
 
 impl<A: Actionlike> BoolTrigger for JustPressedTrigger<A> {
@@ -382,7 +382,7 @@ impl<A: Actionlike> BoolTrigger for JustPressedTrigger<A> {
 }
 
 /// Trigger that transitions while pressing the given [`Actionlike`]
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Debug, Deref, DerefMut, Clone)]
 pub struct PressedTrigger<A: Actionlike>(pub A);
 
 impl<A: Actionlike> BoolTrigger for PressedTrigger<A> {
@@ -403,7 +403,7 @@ impl<A: Actionlike> BoolTrigger for PressedTrigger<A> {
 }
 
 /// Trigger that transitions upon releasing the given [`Actionlike`]
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Debug, Deref, DerefMut, Clone)]
 pub struct JustReleasedTrigger<A: Actionlike>(pub A);
 
 #[cfg(feature = "leafwing_input")]
@@ -425,7 +425,7 @@ impl<A: Actionlike> BoolTrigger for JustReleasedTrigger<A> {
 }
 
 /// Trigger that transitions while the given [`Actionlike`] is released
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Debug, Deref, DerefMut, Clone)]
 pub struct ReleasedTrigger<A: Actionlike>(pub A);
 
 impl<A: Actionlike> BoolTrigger for ReleasedTrigger<A> {
@@ -446,7 +446,7 @@ impl<A: Actionlike> BoolTrigger for ReleasedTrigger<A> {
 }
 
 /// Trigger that always transitions, providing the given [`Actionlike`]'s [`ActionData`]
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Debug, Deref, DerefMut, Clone)]
 pub struct ActionDataTrigger<A: Actionlike>(pub A);
 
 impl<A: Actionlike> Trigger for ActionDataTrigger<A> {


### PR DESCRIPTION
This PR add `Clone` and some common traits onto triggers and some values for convenience.
It is good for reusing triggers.

Implementing `Clone` on `StateMachine` will be convenient too, but it will conflict with pending PR (#7 ), so I won't implement until it is closed (weather merged or not).